### PR TITLE
Updated to node Version 10 for helios2mqtt 0.2.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:8
+FROM node:10
 WORKDIR /usr/local/lib/node_modules/
 RUN npm install helios2mqtt
 CMD [ "helios2mqtt", "start" ]


### PR DESCRIPTION
I Updated helios2mqtt on NPM to 0.2.1 but now we need Node 10.